### PR TITLE
Fix undefined local variable when using min_frequency

### DIFF
--- a/lib/rake-nlp/result.rb
+++ b/lib/rake-nlp/result.rb
@@ -51,7 +51,7 @@ module RakeNLP
 
       phrases.each do |phrase|
         if @options[:min_frequency] > 1
-          next if phrases.count(keyword) < @options[:min_frequency]
+          next if phrases.count(phrase) < @options[:min_frequency]
         end
 
         words = split_words(phrase)

--- a/lib/rake-nlp/version.rb
+++ b/lib/rake-nlp/version.rb
@@ -1,3 +1,3 @@
 module RakeNLP
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
While I tried your library I played around with the parameters, such as `min_frequency`. Turns out, when I set this parameter > 1 a part of the code will be hit that has an incorrect variable name (keyword instead of phrase).

This pull request fixes the issue.